### PR TITLE
Update debian/control for bullseye.

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -4,11 +4,10 @@ Priority: optional
 Maintainer: Jeremy Davis <jeremy@turnkeylinux.org>
 Build-Depends: 
  debhelper (>= 10),
- python3-all (>= 3.5~),
- python3-debian,
- dh-python
+ dh-python,
+ python3-all (>= 3.7~),
+ python3-debian
 Standards-Version: 4.0.0
-X-Python-Version: >= 3.5
 
 Package: deckdebuild
 Architecture: any


### PR DESCRIPTION
Turns out that this possibly wasn't needed, but it includes removal of `X-Python-Version`, so may as well leave it here...

Also, I have an (untested) `postinst` script which may or may not be of value/required. As noted in the PR, I haven't tested it, but perhaps it's of value to include here too?

Thoughts @OnGle ?