### PR TITLE
Tweak install - conf file not being installed?

### DIFF
--- a/debian/deckdebuild.install
+++ b/debian/deckdebuild.install
@@ -1,1 +1,1 @@
-conf/*          /etc/deckdebuild/
+conf/deckdebuild.conf   /etc/deckdebuild/


### PR DESCRIPTION
I'm sure this worked before? But it seems sometime since I last noticed and now, it appears that the conf file wasn't always being installed. This appears to solve that.