### PR TITLE
More bugfixing

### DIFF
--- a/deckdebuild
+++ b/deckdebuild
@@ -136,7 +136,7 @@ def main() -> None:
         help="never leave build chroot intact after build",
     )
     buildroot_cleanup_args.add_argument(
-        "-p",
+        "-P",
         "--preserve-build",
         action="store_const",
         const="always",
@@ -195,7 +195,7 @@ def main() -> None:
             args.path_to_output_dir,
             root_cmd=args.root_cmd,
             user=args.user,
-            preserve_build=args.preserve_build,
+            preserve_build=args.preserve_buildroot,
             faketime=args.faketime,
             satisfydepends_cmd=args.satisfydepends_cmd,
             vardir=args.vardir,

--- a/deckdebuild
+++ b/deckdebuild
@@ -65,6 +65,15 @@ class Config:
             conf_file = CONF_FILE
         with open(conf_file) as fob:
             for line in fob:
+                line = line.strip()
+                if not line:
+                    continue
+                if "#" in line:
+                    line = line.split("#")[0].strip()
+                    if not line:
+                        continue
+                if "=" not in line:
+                    fatal(f"invalid config line ('=' not found): '{line}'")
                 key, value = line.strip().split("=", 1)
                 key = key.replace("-", "_")
                 self._set_conf(key.strip(), value.strip())

--- a/libdeckdebuild/__init__.py
+++ b/libdeckdebuild/__init__.py
@@ -51,22 +51,6 @@ def get_source_dir(name: str, version: str) -> str:
     return name + "-" + version
 
 
-def apply_faketime_patch(chroot: str, user: str) -> None:
-    patch_command = [
-        "find",
-        "-name",
-        "configure",
-        "-exec",
-        "sed",
-        "-i",
-        's/test "$2" = conftest.file/true/',
-        "{}",
-        ";",
-    ]
-
-    system(["chroot", chroot, "su", user, "-l", "-c", *patch_command])
-
-
 def deckdebuild(
     path: str,
     buildroot: str,
@@ -163,9 +147,6 @@ def deckdebuild(
             os.chown(join(root, fn), build_uid_int, build_gid_int)
     os.chown(chr_source_dir, build_uid_int, build_gid_int)
     os.chdir(orig_cwd)
-
-    if faketime:
-        apply_faketime_patch(chroot, user)
 
     # create link to build directory in chroot
     build_dir = chroot + user_home

--- a/libdeckdebuild/__init__.py
+++ b/libdeckdebuild/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) TurnKey GNU/Linux - http://www.turnkeylinux.org
+# Copyright (c) TurnKey GNU/Linux - https//www.turnkeylinux.org
 #
 # This file is part of DeckDebuild
 #


### PR DESCRIPTION
A few of bugfixes...

- handle empty, commented and malformed lines in config file
- fix duplicate `-p` short option
  - I changed the `--preserve-build` short switch to `-P` and left `-p` as the short switch for `--preserve-buildroot-always`; my rationale is that the options themselves provide identical functionality and `--preserve-build` is now deprecated and will be removed at some point in the future
- updated the `args` variable name for the new buildroot preservation functionality - I had overlooked the args variable name change; `args.preserve_build` => `args.preserve_buildroot`
- fix building with faketime - not sure what the `apply_faketime_patch` function was meant to do but it was failing. Even when I ran the `find` command manually it doesn't find any results - so wouldn't do anything if it didn't fail. After removing it the build works fine and the package I tested was reproducible - so I guess it's all working ok...?
- update turnkey URL in `libdeckdebuild/__init__.py` header comment