### PR TITLE
Bugfix error and faketime

### DIFF
--- a/deckdebuild
+++ b/deckdebuild
@@ -115,7 +115,7 @@ def main() -> None:
         "-e",
         "--preserve-buildroot-on-error",
         action="store_const",
-        const="error",
+        const="on-error",
         dest="preserve_buildroot",
         help="leave build chroot intact after build if failure (default)",
     )

--- a/libdeckdebuild/__init__.py
+++ b/libdeckdebuild/__init__.py
@@ -80,7 +80,12 @@ def deckdebuild(
     chroot = join(path_chroots, source_dir)
 
     orig_uid = os.getuid()
-    os.setuid(0)
+    try:
+        os.setuid(0)
+    except PermissionError as e:
+        raise DeckDebuildError(
+            "deckdebuild requires root - please rerun with sudo"
+        ) from e
 
     # delete deck if it already exists
     if exists(chroot):

--- a/libdeckdebuild/__init__.py
+++ b/libdeckdebuild/__init__.py
@@ -213,6 +213,7 @@ def deckdebuild(
     # copy packages
     packages = debsource.get_packages(path)
 
+    copied_deb = False
     for fname in os.listdir(build_dir):
         if (
             not fname.endswith(".deb")
@@ -222,7 +223,6 @@ def deckdebuild(
             and not fname.endswith(".tar.gz")
             and not fname.endswith(".tar.bz2")
         ):
-            error = True
             continue
 
         if fname.split("_")[0] in packages:
@@ -231,8 +231,12 @@ def deckdebuild(
 
             print(f"# cp {shlex.quote(src)} {shlex.quote(dst)}")
             shutil.copyfile(src, dst)
+            # assume that at least one .deb/.udeb copied == success
+            if fname.endswith("deb"):
+                copied_deb = True
 
-    if error:
+    if error or not copied_deb:
+        error = True
         print(
             f"building {source_name}_{source_version} package failed"
             f"\n - see build log ({build_log}) &/or previous output for info",

--- a/libdeckdebuild/__init__.py
+++ b/libdeckdebuild/__init__.py
@@ -55,7 +55,7 @@ def deckdebuild(
     path: str,
     buildroot: str,
     output_dir: str,
-    preserve_build: str = "error",
+    preserve_build: str = "on-error",
     user: str = "build",
     root_cmd: str = "fakeroot",
     satisfydepends_cmd: str = "/usr/lib/pbuilder/pbuilder-satisfydepends",
@@ -63,6 +63,12 @@ def deckdebuild(
     vardir: str = "/var/lib/deckdebuilds",
     build_source: bool = False,
 ) -> None:
+    preserve_build_opts = ("never", "always", "on-error")
+    if preserve_build not in preserve_build_opts:
+        raise DeckDebuildError(
+            "invalid preserve_build value, must be one of"
+            f" {'|'.join(preserve_build_opts)}"
+        )
     vardir = os.fspath(vardir)
 
     path_chroots = join(vardir, "chroots")

--- a/libdeckdebuild/__init__.py
+++ b/libdeckdebuild/__init__.py
@@ -169,7 +169,7 @@ def deckdebuild(
 
     if faketime:
         faketime_fmt = debsource.get_mtime(path).strftime("%Y-%m-%d %H:%M:%S")
-        build_cmd += f"faketime -f {shlex.quote(faketime_fmt)};"
+        build_cmd += f"faketime -f {shlex.quote(faketime_fmt)} "
 
     if build_source:
         build_cmd += (

--- a/libdeckdebuild/__init__.py
+++ b/libdeckdebuild/__init__.py
@@ -86,7 +86,7 @@ def deckdebuild(
     if exists(chroot):
         print(
             f"warning: build chroot deck '{chroot}' exists; removing",
-            file=sys.stderr
+            file=sys.stderr,
         )
         system(["deck", "-D", chroot], prefix="undeck")
 
@@ -130,7 +130,7 @@ def deckdebuild(
                 user,
                 "-l",
                 "-c",
-                'cat /etc/passwd | grep build | cut -d":" -f3,4',
+                "grep '^build:' /etc/passwd | cut -d':' -f3,4",
             ],
             prefix="get uid",
         )
@@ -186,6 +186,7 @@ def deckdebuild(
         )
     except Exception:
         import traceback
+
         traceback.print_exc()
         error = True
     finally:
@@ -229,9 +230,8 @@ def deckdebuild(
     else:
         print(f"built {source_name}_{source_version} successfully")
     preserve_reason = f"(preserve-build = {preserve_build}; error = {error})"
-    if (
-        preserve_build == "never"
-        or (not error and preserve_build == "on-error")
+    if preserve_build == "never" or (
+        not error and preserve_build == "on-error"
     ):
         print(f"deleting {chroot} {preserve_reason}")
         os.seteuid(0)


### PR DESCRIPTION
Fix exiting with an error regardless of success status.

Check for root and provide a useful error message if not.

Ensure faketime uses a reliable and reproducible timestamp.

FYI the timestamp for faketime was coming from the last changelog entry, however pool generates the changelog file dynamically so that is not reproducible. If the source is a git repo, it now uses the mtime of `debian/control` file. It was a somewhat arbitrary choice, but the file will always exist. FYI I had to use git log to get the "real" mtime because the mtime from the local filesystem is clone/last local update. If it's not a git repo, it falls back to the previous default behavior (i.e. last changelog entry).